### PR TITLE
Revised to account for theses and dissertations

### DIFF
--- a/mockups/about-body-v2
+++ b/mockups/about-body-v2
@@ -1,0 +1,65 @@
+<div>
+    <h1 style="margin-left:1em">About DataSpace</h1>
+
+    <br>
+    
+    <div class="max-width:60em; margin-left:2em; margin-right:2em">
+
+    <p>
+        DataSpace is an online repository designed for archiving and publicly disseminating digital objects which are the result of research, academic, or administrative work performed by members of the Princeton University community. It is home to several research data collections, organized by department and/or research center, as well as Princeton Theses and Dissertations and some library collections searchable via the <a href="https://catalog.princeton.edu" target="_blank" rel="noopener">Library Catalog</a>.
+    </p>
+    
+    <br>
+
+    <h3 id="WhyDataSpace">Why does Princeton University have an online data repository?</h3>
+    <blockquote>
+        Princeton University is committed to supporting research that has the potential to benefit humanity at large (see <a href="https://www.princeton.edu/research" target="_blank" rel="noopener">Princeton's spotlight on research</a>). Very often, research conducted by members of the Princeton community is publicly funded and therefore entails an explicit responsibility to share the products of the research openly with taxpayers. Some academic journals have data policies requiring that the evidence backing submitted research papers be posted online for peer review and public scrutiny. An increasing number of Princeton researchers also embrace <a href="https://www.force11.org/about/manifesto" target="_blank" rel="noopener">the principles of open research</a> in general, committing to share their data for the sake of transparency, accountability, and the democratization of knowledge, regardless of whether their funders and publishers require it. DataSpace exists as an institutional conduit for long-term archiving and open dissemination of any digital research data stemming from the Princeton community, meeting funder and publisher expectations, as well as open research principles.
+    </blockquote>
+
+    <h3 id="Access">Who has access to items in DataSpace?</h3>
+    <blockquote>
+        Anyone can browse, download, and investigate the items stored in DataSpace, free of charge. Many, if not most, of these items have an intended audience of other specialists in a given field of research, however, and DataSpace does not provide guides for interpretation or understanding beyond the technical documentation and references to related publications supplied by contributing researchers. In addition, DataSpace users should be cautioned that individual contributors typically retain copyrights to their research works, so permissions may be required for some forms of data use and re-use, depending on the item.
+    </blockquote>
+
+    <h3 id="WhoContributes">Who contributes to DataSpace?</h3>
+    <blockquote>
+        All faculty, staff, students, and affiliates of Princeton University are welcome to submit their digital research data to DataSpace. If you are a Princeton-affiliated researcher and would like to submit your work to DataSpace, please contact the <a href="mailto:dspadmin@princeton.edu">DataSpace curators</a> to get started.
+    </blockquote>
+
+    <h3 id="DataTypes">What types of resources are included in DataSpace?</h3>
+    <blockquote>
+        DataSpace includes digital research data from all academic domains at Princeton--engineering and applied sciences, humanities, natural sciences, and social sciences--as well as digital copies of Theses and Dissertations dating as far back as 1924. Data files range from tabular datasets, to images and videos, to output files from specialty instruments. Items with large files or many files organized in a folder hierarchy are typically compressed into consolidated archive files. Most items also include plain text “README” files to explain what is provided and how it can be used. (For storing and browsing written scholarly works produced by members of the Princeton University community, please refer to the <a href="https://oar.princeton.edu/jspui/" target="_blank" rel="noopener">Open Access Repository</a>. To search for senior theses, please visit the <a href="https://catalog.princeton.edu/?f%5Bformat%5D%5B%5D=Senior+thesis" target="_blank" rel="noopener">Library Catalog.</a>)
+    </blockquote>
+
+    <h3 id="Cite">How should published datasets be cited?</h3>
+    <blockquote>
+        <p>
+        While DataSpace includes items that are licensed to the public domain, the majority of items require attribution for fair use. Moreover, published datasets are increasingly recognized as stand-alone products of academic research, warranting citation customs similar to those of articles and monographs to ensure that the contributors are given credit for their painstaking work (see <a href="https://doi.org/10.1038/d41586-019-01715-4" target="_blank" rel="noopener">a recent Comment article in <i>Nature</i></a>). Conventions for data citation vary by discipline and publisher, but general guidelines are provided in the <a href="https://doi.org/10.25490/a97f-egyk" target="_blank" rel="noopener">Joint Declaration of Data Citation Principles</a>. Further general considerations can be found in <a href="https://doi.org/10.1038/sdata.2018.259" target="_blank" rel="noopener">a recent article in <i>Nature Scientific Data</i></a>, and the Princeton University Library has <a href="https://libguides.princeton.edu/citingdata" target="_blank" rel="noopener">a guide for citing social scientific data</a>. At a minimum, the DataSpace curators recommend that citations for items in DataSpace include the creators/contributors, year of publication, title, publisher, and persistent identifier (<a href="https://www.doi.org/index.html" target="_blank" rel="noopener">DOI</a>, if available).
+        </p><p>
+        Some style guides offer specific standards for dataset citation. For example, the <i>APA Publication Manual, 7th Ed.</i> (2020), Section 10.9 provides for an author-date in-text citation format very similar to that of other research works, with a reference list item format that is supplemented by data repository identifiers, version numbers, and brief type description (see <a href="https://apastyle.apa.org/style-grammar-guidelines/references/examples/data-set-references" target="_blank" rel="noopener">the APA's own example</a>). Here is an example citation for a DataSpace item following the APA style:
+        </p><blockquote>
+        <div style="text-indent: -3em; padding-left: 3em">
+        LaChance, J. & Cohen, D. (2020). <i>Fluorescence Reconstruction Microscopy Data: Keratinocyte (10x) Phase to Nuclei (DAPI)</i> [Data set]. DataSpace. <a href="https://doi.org/10.34770/0pt9-qd20" target="_blank" rel="noopener">https://doi.org/10.34770/0pt9-qd20</a>.
+        </div></blockquote><p>
+        As an alternative example, the <a href="https://ieeeauthorcenter.ieee.org/wp-content/uploads/IEEE-Reference-Guide.pdf" target="_blank" rel="noopener"><i>IEEE Reference Guide</i> (V 11.12.2018)</a>, Section II-D provides details for citing datasets with different forms of identifiers. Here is the above example DataSpace item given instead in the basic format for IEEE:
+        </p><blockquote>
+        J. LaChance and D. Cohen, “Fluorescence Reconstruction Microscopy Data: Keratinocyte (10x) Phase to Nuclei (DAPI).” (March 2, 2020). Distributed by DataSpace. <a href="https://doi.org/10.34770/0pt9-qd20" target="_blank" rel="noopener">https://doi.org/10.34770/0pt9-qd20</a>.
+        </p></blockquote><p>
+        And as a third example, <a href="https://www.nature.com/nature/for-authors/formatting-guide" target="_blank" rel="noopener"><i>Nature</i> journals</a> allow research datasets to be cited in reference lists if they have DOIs. Here is the above example DataSpace item citation again in the <i>Nature</i> format:
+        </p><blockquote>
+        LaChance, J. & Cohen, D. Fluorescence Reconstruction Microscopy Data: Keratinocyte (10x) Phase to Nuclei (DAPI). DataSpace <a href="https://doi.org/10.34770/0pt9-qd20" target="_blank" rel="noopener">https://doi.org/10.34770/0pt9-qd20</a> (2020).
+        </blockquote>
+    </blockquote>
+
+    <h3 id="Implementation">How is DataSpace implemented?</h3>
+    <blockquote>
+        DataSpace is an implementation of the <a href="https://duraspace.org/dspace/" target="_blank" rel="noopener">DSpace platform</a>, a common software solution for universities hosting digital repositories. Staff from the Princeton Office of Information Technology customized DSpace for Princeton’s use case, and staff from the Princeton University Library are currently involved in updating and improving the platform.
+    </blockquote>
+
+    <h3 id="Management">Who manages DataSpace?</h3>
+    <blockquote>
+        Research data communities in DataSpace are managed and curated by the <a href="https://researchdata.princeton.edu" target="_blank" rel="noopener">Princeton Research Data Service</a>, with technical support from information technology staff at the Princeton University Library. The curators of DataSpace review submissions with an eye toward discoverability, re-usability, and long-term preservation--without partiality to the subject matter or findings of the research. For general questions related to DataSpace, please contact the <a href="mailto:dspadmin@princeton.edu">curators</a>. For help accessing theses and dissertations, please <a href="https://library.princeton.edu/special-collections/ask-us">contact Mudd Library</a>.
+    </blockquote>
+    <br>
+    <br>
+</div>


### PR DESCRIPTION
This includes the revised body content for the "About" page. The revisions mostly pertain to the need to account for theses and dissertations in DataSpace.

I'm still working on revisions for the "Help" page.